### PR TITLE
removed test node.

### DIFF
--- a/test.moersdorf-hunsrueck.de
+++ b/test.moersdorf-hunsrueck.de
@@ -1,3 +1,0 @@
-#Name: test.moersdorf-hunsrueck.de
-#MAC: e8:94:f6:78:2f:ac
-key "528aa198d6f4bf745d022ac74b6382a611ba9e8dd98c998384d113439028e59a";


### PR DESCRIPTION
Test Knoten test.moersdorf-hunsrueck.de ist jetzt zu ff myk gewechselt, kann also hier gelöscht werden.

Siehe auch #12 
